### PR TITLE
Update SDK constraints so it works with Dart 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .pub/
 build/
 **/packages/
+.dart_tool
 
 # Files created by dart2js
 # (Most Dart developers will use pub build to compile Dart, use/modify these 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,11 +5,11 @@ author: Steven Roose <stevenroose@gmail.com>
 homepage: https://github.com/dartcoin/base58check
 
 environment:
-  sdk: ">=1.0.0 <2.0.0"
+  sdk: ">=1.0.0 <3.0.0"
 
 dependencies:
   crypto: ">=0.9.2 <3.0.0"
   collection: ">=1.2.0 <2.0.0"
 
 dev_dependencies:
-  test: ">=0.12.0 <0.13.0"
+  test: ">=0.12.0"


### PR DESCRIPTION
I've ran the tests and they all pass.

I can optionally run `dartfmt` to get rid of the now optional `new` keywords. Let me know if you want that, then I'll create a new PR.