### PR TITLE
Migrate null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0
+- Migrate to null safety.
+
 ## 1.0.1
 
 Support Dart v2.

--- a/lib/base58.dart
+++ b/lib/base58.dart
@@ -88,7 +88,7 @@ class Base58Decoder extends Converter<String, List<int>> {
     if (input.length == 0) return new Uint8List(0);
 
     // generate base 58 index list from input string
-    List<int> input58 = new List(input.length);
+    var input58 = List<int>.filled(input.length, 0);
     for (int i = 0; i < input.length; i++) {
       int charint = alphabet.indexOf(input[i]);
       if (charint < 0)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: base58check
 description: Base58Check encoding using dart:convert interface
-version: 1.0.1
+version: 2.0.0
 author: Steven Roose <stevenroose@gmail.com>
 homepage: https://github.com/dartcoin/base58check
 
 environment:
-  sdk: ">=1.0.0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  crypto: ">=0.9.2 <3.0.0"
-  collection: ">=1.2.0 <2.0.0"
+  crypto: ^3.0.0
+  collection: ^1.15.0
 
 dev_dependencies:
-  test: ">=0.12.0"
+  test: ^1.16.2


### PR DESCRIPTION
This migrates `base58check` to null safety. All tests appear to be passing.